### PR TITLE
Convert all database entities to snake case

### DIFF
--- a/ApplicationDbContext.cs
+++ b/ApplicationDbContext.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using RepostAspNet.Models;
 
@@ -18,8 +19,44 @@ namespace RepostAspNet
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
+            base.OnModelCreating(builder);
+
+            // Assign composite keys to vote tables
             builder.Entity<PostVote>().HasKey(p => new {p.UserId, p.PostId});
             builder.Entity<CommentVote>().HasKey(c => new {c.UserId, c.CommentId});
+
+            // Convert all PascalCase names to snake_case
+            foreach (var entity in builder.Model.GetEntityTypes())
+            {
+                entity.SetTableName(ToSnakeCase(entity.GetTableName()));
+
+                foreach (var property in entity.GetProperties())
+                {
+                    property.SetColumnName(ToSnakeCase(property.GetColumnName()));
+                }
+
+                foreach (var key in entity.GetKeys())
+                {
+                    key.SetName(ToSnakeCase(key.GetName()));
+                }
+
+                foreach (var key in entity.GetForeignKeys())
+                {
+                    key.SetConstraintName(ToSnakeCase(key.GetConstraintName()));
+                }
+
+                foreach (var index in entity.GetIndexes())
+                {
+                    index.SetName(ToSnakeCase(index.GetName()));
+                }
+            }
+        }
+
+        private string ToSnakeCase(string text)
+        {
+            return string.IsNullOrEmpty(text)
+                ? text
+                : Regex.Replace(text, @"([a-z0-9])([A-Z])", "$1_$2").ToLower();
         }
     }
 }


### PR DESCRIPTION
PostgreSQL syntax is normally snake_case, but with ASP.NET the default is PascalCase. This leads to queries having to be written with table names and column names in quotes (for some reason?).

This PR fixes that, although it was originally supposed to keep consistent names to the other APIs when performing ORM. That is no longer a requirement as we've decided there is too much workload in trying to ensure ORM is identical on each API when this was not in the original spec of the project.